### PR TITLE
Vaadin7: .gitignore, version-properties, SNAPSHOT release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+# maven
+target/
+# eclipse
+.project
+.classpath
+.settings
+# OS
+.DS_Store

--- a/pom.xml
+++ b/pom.xml
@@ -3,10 +3,12 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.vaadin.virkki</groupId>
 	<artifactId>cdi-utils</artifactId>
-	<version>2.2.0</version>
+	<version>2.2.0-SNAPSHOT</version>
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <vaadin.version>7.0.5</vaadin.version>
+        <vaadin-cdi.version>1.0.0.alpha1</vaadin-cdi.version>
 	</properties>
 
 
@@ -14,7 +16,7 @@
 		<dependency>
 			<groupId>com.vaadin</groupId>
 			<artifactId>vaadin-cdi</artifactId>
-			<version>1.0.0.alpha1</version>
+			<version>${vaadin-cdi.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>javax.enterprise</groupId>
@@ -25,7 +27,7 @@
 		<dependency>
 			<groupId>com.vaadin</groupId>
 			<artifactId>vaadin-server</artifactId>
-			<version>7.0.0.rc2</version>
+			<version>${vaadin.version}</version>
 			<scope>provided</scope>
 		</dependency>
 	</dependencies>
@@ -33,6 +35,7 @@
 
 
 	<build>
+        <defaultGoal>clean install</defaultGoal>
 		<resources>
 			<resource>
 				<directory>src/main/java</directory>


### PR DESCRIPTION
Hi Tomi,

I started to work on your vaadin7 branch. First thing I had to was adding a .gitignore file, please include this in the branch, so every developer can profit from one common file.

2nd, I added version-properties for the vaadin deps and updated them to the latest versions (7.05). 

3rd, I set the version to 2.2.0-SNAPSHOT. Since I clean/install a lot during development, the SNAPSHOT flag eases separation of build/intergration artifacts and released artifacts.

regards
Jan

ps: thanks for finally mavenizing this great project! 
